### PR TITLE
Add support for couch databases without authentication

### DIFF
--- a/del.js
+++ b/del.js
@@ -17,7 +17,11 @@ function del (couch, user, pass, id, rev, callback) {
     })
   }
 
-  hyperquest.delete(couch + replicatorBase + id + '?rev=' + rev, { auth: user + ':' + pass })
+  var options = { }
+  if(user && pass)
+    options.auth = user + ':' + pass
+
+  hyperquest.delete(couch + replicatorBase + id + '?rev=' + rev, options)
     .pipe(bl(function (err, data) {
       if (err)
         return callback(err)

--- a/get.js
+++ b/get.js
@@ -5,7 +5,11 @@ const hyperquest     = require('hyperquest')
 
 
 function get (couch, user, pass, id, callback) {
-  hyperquest(couch + replicatorBase + id, { auth: user + ':' + pass })
+  var options = { }
+  if(user && pass)
+    options.auth = user + ':' + pass
+
+  hyperquest(couch + replicatorBase + id, options)
     .pipe(bl(function (err, data) {
       if (err)
         return callback(err)

--- a/put.js
+++ b/put.js
@@ -26,14 +26,16 @@ function put (couch, user, pass, id, doc, callback) {
 
   var data    = JSON.stringify(doc)
     , options = {
-          auth: user + ':' + pass
-        , headers: {
+        headers: {
               'content-type'   : 'application/json'
             , 'content-length' : data.length
             , 'referer'        : url.parse(couch).hostname
-          }
+        }
       }
-    , req  = hyperquest.put(couch + replicatorBase + id, options)
+  if(user && pass)
+    options.auth = user + ':' + pass;
+
+  var req  = hyperquest.put(couch + replicatorBase + id, options)
 
   req.pipe(bl(function (err, data) {
       if (err)

--- a/status.js
+++ b/status.js
@@ -5,7 +5,11 @@ const hyperquest = require('hyperquest')
 
 
 function status (couch, user, pass, target, callback) {
-  hyperquest(couch + statusUrl, { auth: user + ':' + pass }).pipe(bl(function (err, data) {
+  var options = { }
+  if(user && pass)
+    options.auth = user + ':' + pass
+
+  hyperquest(couch + statusUrl, options).pipe(bl(function (err, data) {
     if (err)
       return callback(err)
 


### PR DESCRIPTION
Allows access to couch without authentication by setting user and/or pass to anything that is boolean false (false, null, undefined etc).

Example usage:

``` js
const CouchReplicator = require('couch-replicator-api')

    , replicator = new CouchReplicator(
          'http://npm.nodejs.org.au:5984'
        , false
        , false
        , 'registry'
      )
```
