### PR TITLE
Add support for custom _replicator id

### DIFF
--- a/couch-replicator-api.js
+++ b/couch-replicator-api.js
@@ -1,31 +1,42 @@
-
-function CouchReplicatorApi (url, user, pass, db) {
+/**
+ * @constructor CouchReplicatorApi
+ * @param {string} url - The url of couch
+ * @param {string} user - The username of couch
+ * @param {string} pass - The password of couch
+ * @param {string|false} db - The database of the replication (may be false if doc_id param is set)
+ * @param {string|false} [doc_id] - The doc_id of the replication (may be false if db param is set) (optional)
+ * @returns {CouchReplicatorApi}
+ */
+function CouchReplicatorApi (url, user, pass, db, doc_id) {
   if (!(this instanceof CouchReplicatorApi))
     return new CouchReplicatorApi(url, user, pass)
 
-  this.url  = url
-  this.user = user
-  this.pass = pass
-  this.db   = db
+  this.url    = url
+  this.user   = user
+  this.pass   = pass
+  this.db     = db
+  this.doc_id = false
+  if(doc_id)
+    this.doc_id = doc_id
 }
 
 CouchReplicatorApi.prototype.status = function (callback) {
-  CouchReplicatorApi.status(this.url, this.user, this.pass, this.db, callback)
+  CouchReplicatorApi.status(this.url, this.user, this.pass, this.db, this.doc_id, callback)
 }
 
 
 CouchReplicatorApi.prototype.get    = function (callback) {
-  CouchReplicatorApi.get(this.url, this.user, this.pass, this.db, callback)
+  CouchReplicatorApi.get(this.url, this.user, this.pass, (this.doc_id?this.doc_id:this.db), callback)
 }
 
 
 CouchReplicatorApi.prototype.put    = function (doc, callback) {
-  CouchReplicatorApi.put(this.url, this.user, this.pass, this.db, doc, callback)
+  CouchReplicatorApi.put(this.url, this.user, this.pass, (this.doc_id?this.doc_id:this.db), doc, callback)
 }
 
 
 CouchReplicatorApi.prototype.del    = function (rev, callback) {
-  CouchReplicatorApi.del(this.url, this.user, this.pass, this.db, rev, callback)
+  CouchReplicatorApi.del(this.url, this.user, this.pass, (this.doc_id?this.doc_id:this.db), rev, callback)
 }
 
 

--- a/status.js
+++ b/status.js
@@ -4,7 +4,12 @@ const hyperquest = require('hyperquest')
     , statusUrl  = '/_active_tasks'
 
 
-function status (couch, user, pass, target, callback) {
+function status (couch, user, pass, target, doc_id, callback) {
+  if (typeof doc_id == 'function') {
+    var callback = doc_id
+      , doc_id = false
+  }
+
   hyperquest(couch + statusUrl, { auth: user + ':' + pass }).pipe(bl(function (err, data) {
     if (err)
       return callback(err)
@@ -18,6 +23,8 @@ function status (couch, user, pass, target, callback) {
       return callback(new Error('Unexpected response from couch: ' + data.toString()))
 
     _data = _data.filter(function (s) {
+      if(doc_id)
+        return s && s.type == 'replication' && s.doc_id == doc_id
       return s && s.type == 'replication' && s.target == target
     })[0]
 


### PR DESCRIPTION
couch-replicator-api.js:
- Add doc_id parameter to CouchReplicatorApi constructor (May be omitted for backward compatibility)
- Add automatic selection of doc_id or db to get, put, del functions (doc_id takes preference over db)
- Add JSDoc for CouchReplicatorApi constructor

status.js:
- Add doc_id parameter to status function (May be omitted for backward compatibility)
- Change filter to match on doc_id if set (instead of target)

Example usage:

``` js
const CouchReplicator = require('couch-replicator-api')

    , replicator = new CouchReplicator(
          'http://npm.nodejs.org.au:5984'
        , 'user'
        , 'pass'
        , 'registry',
        , 'registry_to_127.0.0.1:5984'
      )
```
